### PR TITLE
商品詳細表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,6 @@ gem 'devise'
 gem 'image_processing', '~> 1.2' # 画像処理用のgem
 gem 'active_hash'
 gem 'ruby-vips'
+
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  mini_magick
   mysql2 (~> 0.5)
   pg
   puma (~> 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-
+  before_action :set_item, only: [:show, ]
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -25,5 +25,9 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image, :item_name, :explanation, :category_id, :grade_id, :postage_id, :date_of_shipment_id, :prefecture_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/models/date_of_shipment.rb
+++ b/app/models/date_of_shipment.rb
@@ -1,4 +1,4 @@
-class ShippingDay < ActiveHash::Base
+class DateOfShipment < ActiveHash::Base
   self.data = [
     { id: 0, name: '--' },
     { id: 1, name: '1~2日で発送' },

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -1,4 +1,4 @@
-class ProductCondition < ActiveHash::Base
+class Grade < ActiveHash::Base
   self.data = [
     { id: 0, name: '--' },
     { id: 1, name: '新品、未使用' },

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,8 +11,8 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :postage
   belongs_to :prefecture
-  belongs_to :product_condition
-  belongs_to :shipping_day
+  belongs_to :grade
+  belongs_to :date_of_shipment
  
   # バリデーション
   with_options presence: true do

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,9 +130,9 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+       <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -53,7 +53,7 @@
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:grade_id, ProductCondition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:grade_id, Grade.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
 
       </div>
     </div>
@@ -80,7 +80,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:date_of_shipment_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:date_of_shipment_id, DateOfShipment.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? %> 
     <% if current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
@@ -39,10 +38,9 @@
   <% end %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -107,9 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,12 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <% if @item.image.attached? %>
+  <%= image_tag @item.image, class: "item-img" %>
+<% end %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,23 +18,25 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.postage.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? %> 
+    <% if current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%# //商品が売れていない場合はこちらを表示しましょう %> 
+  <% end %>
+  <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
@@ -44,27 +48,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.grade.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.date_of_shipment.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Furima40208
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.active_storage.variant_processor = :mini_magick
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :item do
     user { create(:user) }
-    item_name           { Faker::Name.name }
-    explanation         { Faker::Lorem.sentence }
-    category_id         { Faker::Number.between(from: 1, to: 10) }
-    grade_id            { Faker::Number.between(from: 1, to: 6) }
-    postage_id          { Faker::Number.between(from: 1, to:2) }
-    date_of_shipment_id { Faker::Number.between(from: 1, to: 3) }
-    prefecture_id       { Faker::Number.between(from: 1, to: 47) }
-    price               { Faker::Number.between(from: 300, to: 9_999_999) }
-    image               { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'test_image.png'), 'image/png') }
+    item_name            { Faker::Name.name }
+    explanation          { Faker::Lorem.sentence }
+    category_id          { Faker::Number.between(from: 1, to: 10) }
+    grade_id             { Faker::Number.between(from: 1, to: 6) }
+    postage_id           { Faker::Number.between(from: 1, to:2) }
+    date_of_shipment_id  { Faker::Number.between(from: 1, to: 3) }
+    prefecture_id        { Faker::Number.between(from: 1, to: 47) }
+    price                { Faker::Number.between(from: 300, to: 9_999_999) }
+    image                { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'test_image.png'), 'image/png') }
   end
 end


### PR DESCRIPTION
# What
- 商品詳細表示ページは、ログイン状況や商品の販売状況に関係なく、誰でも見ることができること。
- 商品一覧ページにて商品情報をクリックすると、該当する商品の商品詳細表示ページへ遷移すること。
- 商品出品時に登録した情報（商品名・商品画像・価格・配送料の負担・商品の説明・出品者名・カテゴリー・商品の状態・発送元の地域・発送日の目安）が、見本アプリと同様の形で表示されること。
- 画像が表示されており、画像がリンク切れなどにならないこと。
- ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示されること。
- ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示されること。
- ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。
- ログアウト状態の場合は、商品の販売状況に関わらず、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。
- 売却済みの商品は、画像上に「sold out」の文字が表示されること。

# Why
実装条件を満足させるため

# 動作確認
- ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
URL：https://gyazo.com/5b178cddf5e0d16a56960e8973f3d3b1
- ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
URL：https://gyazo.com/57a60358ad86858b284e0b5424d0684f
- ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
URL：
- ログアウト状態で、商品詳細ページへ遷移した動画
URL：https://gyazo.com/73d62a532f6da611cc6a5e5717f1da4c

