### PR TITLE
商品削除機能_実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,7 +36,6 @@ class ItemsController < ApplicationController
   
 
     def destroy
-      @item = Item.find(params[:id])
       if @item.user_id == current_user.id
         @item.destroy
         redirect_to root_path, notice: '商品が削除されました。'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -33,6 +33,18 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+  
+
+    def destroy
+      @item = Item.find(params[:id])
+      if @item.user_id == current_user.id
+        @item.destroy
+        redirect_to root_path, notice: '商品が削除されました。'
+      else
+        redirect_to item_path(@item), alert: '削除権限がありません。'
+      end
+    end
+
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
# What
- ログイン状態の場合にのみ、自身が出品した商品情報を削除できること。
- 削除が完了したら、トップページに遷移すること。
# Why
- 実装条件を満足させる為
# 動作確認
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
URL：https://gyazo.com/128ecc6e2a1ad2269f4874323164311d